### PR TITLE
Fix duplicate material name

### DIFF
--- a/sample-pipelines.gocd.yaml
+++ b/sample-pipelines.gocd.yaml
@@ -20,7 +20,7 @@ pipelines:
   action-movies-manual:
     group: movies
     materials:
-      action:
+      action-manual:
         plugin_configuration:
           id: git-path
         options:


### PR DESCRIPTION
Latest version of Gocd doesn't allow to have duplicate names for git material. This PR fixes the sample pipeline configuration